### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vpoptani/jenkinsx-tutorial](https://github.com/vpoptani/jenkinsx-tutorial.git) |  | []() | 
+[vpoptani/hls2](https://github.com/vpoptani/hls2.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vpoptani/jenkinsx-tutorial](https://github.com/vpoptani/jenkinsx-tutorial.git) |  | []() | 
-[vpoptani/hls2](https://github.com/vpoptani/hls2.git) |  | []() | 
+[vpoptani/jx-quickstart](https://github.com/vpoptani/jx-quickstart.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [vpoptani/jenkinsx-tutorial](https://github.com/vpoptani/jenkinsx-tutorial.git) |  | []() | 
-[vpoptani/jx-quickstart](https://github.com/vpoptani/jx-quickstart.git) |  | []() | 
+[vpoptani/hls2](https://github.com/vpoptani/hls2.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/vpoptani/jenkinsx-tutorial.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: vpoptani
+  repo: hls2
+  url: https://github.com/vpoptani/hls2.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: vpoptani
-  repo: jx-quickstart
-  url: https://github.com/vpoptani/jx-quickstart.git
+  repo: hls2
+  url: https://github.com/vpoptani/hls2.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: vpoptani
-  repo: hls2
-  url: https://github.com/vpoptani/hls2.git
+  repo: jx-quickstart
+  url: https://github.com/vpoptani/jx-quickstart.git
   version: ""
   versionURL: ""

--- a/repositories/templates/vpoptani-hls2-sr.yaml
+++ b/repositories/templates/vpoptani-hls2-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "1"
   creationTimestamp: null
   labels:
     owner: vpoptani

--- a/repositories/templates/vpoptani-hls2-sr.yaml
+++ b/repositories/templates/vpoptani-hls2-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vpoptani
+    provider: github
+    repository: hls2
+  name: vpoptani-hls2
+spec:
+  description: Imported application for vpoptani/hls2
+  httpCloneURL: https://github.com/vpoptani/hls2.git
+  org: vpoptani
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: hls2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vpoptani/hls2.git

--- a/repositories/templates/vpoptani-jx-quickstart-sr.yaml
+++ b/repositories/templates/vpoptani-jx-quickstart-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vpoptani
+    provider: github
+    repository: jx-quickstart
+  name: vpoptani-jx-quickstart
+spec:
+  description: Imported application for vpoptani/jx-quickstart
+  httpCloneURL: https://github.com/vpoptani/jx-quickstart.git
+  org: vpoptani
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-quickstart
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/vpoptani/jx-quickstart.git


### PR DESCRIPTION
Update [vpoptani/hls2](https://github.com/vpoptani/hls2.git) 

Command run was `jx import --git-username=vpoptani --git-api-token=b2e49c32701de897d4920f632a46d7cff8195043`
<hr />

Update [vpoptani/jx-quickstart](https://github.com/vpoptani/jx-quickstart.git) 

Command run was `jx create quickstart`
<hr />

Update [vpoptani/hls2](https://github.com/vpoptani/hls2.git) 

Command run was `jx import --git-username=vpoptani --git-api-token=b2e49c32701de897d4920f632a46d7cff8195043`